### PR TITLE
Quickfix for a crash if user count is too low

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /logs/
 /data/
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /logs/
 /data/
-/.idea/
+.idea/

--- a/src/data_generation.py
+++ b/src/data_generation.py
@@ -479,7 +479,7 @@ def assign_group_owner(user_group, item_list, rng=Random()):
         if member in users:
             candidate_owner_uuids.append(member['uuid'])
 
-    if candidate_owner_uuids.__len__() > 0:  # This is a quickfix for a crash with 0 members in the group documentation
+    if len(candidate_owner_uuids) > 0:  # This is a quickfix for a crash with 0 members in the group documentation
                                              # if `user_count` is too low
         user_group['owner'] = [rng.choice(candidate_owner_uuids)]
     else:

--- a/src/data_generation.py
+++ b/src/data_generation.py
@@ -479,7 +479,11 @@ def assign_group_owner(user_group, item_list, rng=Random()):
         if member in users:
             candidate_owner_uuids.append(member['uuid'])
 
-    user_group['owner'] = [rng.choice(candidate_owner_uuids)]
+    if candidate_owner_uuids.__len__() > 0:  # This is a quickfix for a crash with 0 members in the group documentation
+                                             # if `user_count` is too low
+        user_group['owner'] = [rng.choice(candidate_owner_uuids)]
+    else:
+        user_group['owner'] = [rng.choice(users)['uuid']]
 
 
 def assign_group_owners(item_list, rng=Random()):


### PR DESCRIPTION
Fixing a crash due to 0 members (and 0 candidates) for user_group documentation if `user count` setting is too low.